### PR TITLE
Fix typo in minLength validation translation key

### DIFF
--- a/src/checkError.ts
+++ b/src/checkError.ts
@@ -27,7 +27,7 @@ export default function checkError<T, K extends DotNestedKeys<T>>(
     } else if (h.minLength !== undefined && `${v}`.length < h.minLength) {
       err = getTranslation(
         locale,
-        'lengtShouldBeLongerThan'
+        'lengthShouldBeLongerThan'
       )({
         fieldKey: k,
         label: h?.label,


### PR DESCRIPTION
The translation key `lengtShouldBeLongerThan` contained a typo ('lengt' instead of 'length'). This PR corrects it to `lengthShouldBeLongerThan` to ensure proper translation lookup during minLength validation errors.

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.